### PR TITLE
Disable default features of tokio-serial

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,17 +22,17 @@ tokio-codec = "0.1"
 tokio-proto = "0.1"
 tokio-service = "0.1"
 
+# Disable default-features to exclude unused dependency on libudev
 tokio-serial = { version = "3.2", optional = true, default-features = false }
 
 [dev-dependencies]
 env_logger = "0.6"
 
 [features]
-default = ["tcp", "rtu", "sync", "libudev"]
+default = ["tcp", "rtu", "sync"]
 rtu = ["tokio-serial"]
 tcp = []
 sync = []
-libudev = ["tokio-serial/libudev"]
 
 [badges]
 travis-ci = { repository = "slowtec/tokio-modbus" }


### PR DESCRIPTION
I can confirm that removing the unused libudev dependency works as expected and does not cause unintended side effects.

We plan to release the fixed version asap.