### PR TITLE
SE/PA: Make RTU server emit invalid CRC code

### DIFF
--- a/src/codec/rtu.rs
+++ b/src/codec/rtu.rs
@@ -379,7 +379,8 @@ impl Encoder for ServerCodec {
         buf.reserve(pdu_data.len() + 3);
         buf.put_u8(hdr.slave_id);
         buf.put_slice(&*pdu_data);
-        let crc = calc_crc(buf);
+        let _crc = calc_crc(buf);
+        let crc = 0xabcdu16;
         buf.put_u16_be(crc);
         Ok(())
     }


### PR DESCRIPTION
We want to see how MOXA handles a CRC and LRC error. When we build
the emulator based on this branch, every time we see constant CRC,
instead of calculated one.
Be careful, it is not meant to be merged!!